### PR TITLE
Add Experiment API for structured multi-run logs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install -e . pytest
+        python -m pip install -e .[dev]
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
     - name: Test with pytest

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -11,3 +11,4 @@ Tutorials
    tutorials/artifacts
    tutorials/failures
    tutorials/shell_usage
+   tutorials/experiment

--- a/docs/source/tutorials/experiment.rst
+++ b/docs/source/tutorials/experiment.rst
@@ -1,0 +1,107 @@
+Experiment Management
+===========================================
+
+The ``Experiment`` object in ``notata`` is designed to organize and track multiple related runs using ``Logbook``. It simplifies the process of sweeping parameters, aggregating metrics, and building an index of all results.
+
+Quickstart
+----------
+
+.. code-block:: python
+
+    from notata import Experiment
+
+    exp = Experiment("oscillator_sweep")
+
+    for omega in [1.0, 2.0]:
+        for dt in [1e-3, 2e-3]:
+            log = exp.add(omega=omega, dt=dt, steps=10_000, skip_existing=True)
+
+            if log is None:
+                continue  # skip if this run already exists
+
+            with log:
+                # Your simulation code here
+                ...
+                log.json("metrics", {"final_energy": 0.993})
+            # Exiting the context manager automatically marks the run as complete.
+
+Manual Logging (without context manager)
+----------------------------------------
+
+You can also explicitly call ``mark_complete()`` after your run logic:
+
+.. code-block:: python
+
+    log = exp.add(omega=3.0, dt=1e-3, steps=5000)
+
+    try:
+        # run your simulation
+        ...
+        log.json("metrics", {"final_energy": 0.998})
+        log.mark_complete()  # explicitly mark success
+    except Exception as e:
+        log.mark_failed(str(e))
+
+What it does
+------------
+
+The ``Experiment`` handles:
+
+- Constructing unique log directories per parameter set.
+- Attaching a callback so that calling ``log.mark_complete()`` or ``log.mark_failed()`` auto-updates an ``index.csv``.
+- Persisting parameters and user-defined metrics for each run.
+
+Directory Layout
+----------------
+
+.. code-block:: text
+
+    outputs/oscillator_sweep/
+      index.csv
+      runs/
+        log_oscillator_sweep_dt_0.001_omega_1.0/
+        log_oscillator_sweep_dt_0.002_omega_1.0/
+        log_oscillator_sweep_dt_0.001_omega_2.0/
+        log_oscillator_sweep_dt_0.002_omega_2.0/
+
+Each run gets its own ``Logbook`` with full logging, metadata, and artifacts.
+
+Inspecting Results
+------------------
+
+You can convert the index to a pandas dataframe and filter completed runs:
+
+.. code-block:: python
+
+    df = exp.to_dataframe()
+    complete = df[df["status"] == "complete"]
+    print(complete[["omega", "dt", "final_energy"]])
+
+Example **index** after running one log:
+
+.. list-table::
+   :header-rows: 1
+
+   * - run_id
+     - omega
+     - dt
+     - steps
+     - status
+     - final_energy
+   * - oscillator_sweep_dt_0.001_omega_1.0
+     - 1.0
+     - 0.001
+     - 10000
+     - complete
+     - 0.993
+
+Convenience
+-----------
+
+The key benefit of ``Experiment`` is that it removes the need for manual bookkeeping across many runs. Just:
+
+- Use ``exp.add(...)`` instead of manually constructing directories.
+- Store metrics in ``artifacts/metrics.json``.
+- Use ``log.mark_complete()`` or ``with log: ...``.
+
+The index is built incrementally and is ready for downstream analysis or re-running filtered subsets.

--- a/notata/__init__.py
+++ b/notata/__init__.py
@@ -1,8 +1,10 @@
 from notata.logbook import Logbook
+from notata.experiment import Experiment
 
 __version__ = "0.1.0"
 
 __all__ = [
     "Logbook",
+    "Experiment",
     "__version__",
       ]

--- a/notata/experiment.py
+++ b/notata/experiment.py
@@ -1,0 +1,87 @@
+from functools import partial
+import csv
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from notata.logbook import Logbook
+
+
+class Experiment:
+    def __init__(self, name: str, base_dir: Path | str = "outputs"):
+        self.name = name
+        self.base_dir = Path(base_dir)
+        self.exp_dir = self.base_dir / name
+        self.runs_dir = self.exp_dir / "runs"
+        self.index_file = self.exp_dir / "index.csv"
+
+        self.runs_dir.mkdir(parents=True, exist_ok=True)
+
+    def add(self, skip_existing = False, **params) -> Logbook | None:
+        run_id = self._generate_run_id(params)
+        logdir = logdir = self.runs_dir / f"log_{run_id}"
+
+        if skip_existing and logdir.exists():
+            return None
+
+        log = Logbook(
+            run_id=run_id,
+            base_dir=self.runs_dir,
+            params=params,
+            overwrite=False,
+            preallocate=True,
+            callback = partial(self.record, metrics_file="artifacts/metrics.json")
+        )
+        return log
+
+    def record(self, log: Logbook, metrics_file: str = "artifacts/metrics.json"):
+        run_data = {
+            "run_id": log.run_id,
+            **log._load_params(),
+            "status": log.status,
+            **self._read_metrics(log.path / metrics_file),
+        }
+        self._append_to_index(run_data)
+
+    def _generate_run_id(self, params: Dict[str, Any]) -> str:
+        parts = [f"{k}_{self._safe_str(v)}" for k, v in sorted(params.items())]
+        return f"{self.name}_" + "_".join(parts)
+
+    def _safe_str(self, val) -> str:
+        if isinstance(val, float):
+            return f"{val:.5g}"
+        return str(val).replace("/", "_").replace(" ", "_")
+
+    def _read_metrics(self, path: Path) -> Dict[str, Any]:
+        if not path.exists():
+            return {"status": "missing"}
+        try:
+            with open(path) as f:
+                data = json.load(f)
+            return {"status": "complete", **data}
+        except Exception as e:
+            return {"status": "error", "error_reason": str(e)}
+
+    def _append_to_index(self, row: Dict[str, Any]):
+        header_exists = self.index_file.exists()
+
+        with self.index_file.open("a", newline="") as csvfile:
+            writer = csv.DictWriter(csvfile, fieldnames=row.keys())
+            if not header_exists:
+                writer.writeheader()
+            writer.writerow(row)
+
+    def to_dataframe(self):
+        try:
+            import pandas as pd
+        except ImportError:
+            raise ImportError("pandas is required to convert experiment data to a DataFrame.")
+        if not self.index_file.exists():
+            return pd.DataFrame()
+        return pd.read_csv(self.index_file)
+
+    def select(self, **filters):
+        df = self.to_dataframe()
+        for key, val in filters.items():
+            df = df[df[key] == val]
+        return df

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ license = {file = "LICENSE"}
 requires-python = ">=3.8"
 dependencies = [
   "numpy",
-  "matplotlib",
   "pyyaml"
 ]
 
@@ -20,3 +19,11 @@ version = {attr = "notata.__version__"}
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[project.optional-dependencies]
+dev = [
+  "matplotlib",
+  "pandas",
+  "pytest",
+  "pytest-cov"
+]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,0 +1,96 @@
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from notata import Experiment, Logbook
+
+
+@pytest.fixture
+def temp_dir():
+    path = Path(tempfile.mkdtemp())
+    yield path
+    shutil.rmtree(path)
+
+
+def test_add_creates_logbook(temp_dir):
+    exp = Experiment("test_exp", base_dir=temp_dir)
+    log = exp.add(omega=1.0, dt=0.01)
+    assert log.path.exists()
+    assert (log.path / "params.yaml").exists()
+
+
+def test_record_writes_to_index(temp_dir):
+    exp = Experiment("test_exp", base_dir=temp_dir)
+    log = exp.add(alpha=0.5)
+
+    metrics_path = log.path / "artifacts" / "metrics.json"
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(metrics_path, "w") as f:
+        json.dump({"final_loss": 0.123}, f)
+
+    exp.record(log)
+
+    index_file = exp.index_file
+    assert index_file.exists()
+    with open(index_file) as f:
+        lines = f.readlines()
+    assert "run_id" in lines[0]
+    assert "test_exp_alpha_0.5" in lines[1]
+
+
+def test_select_filters_results(temp_dir):
+    exp = Experiment("test_exp", base_dir=temp_dir)
+
+    for a in [0.1, 0.2]:
+        log = exp.add(a=a)
+        metrics_path = log.path / "artifacts" / "metrics.json"
+        metrics_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(metrics_path, "w") as f:
+            json.dump({"score": a * 10}, f)
+        exp.record(log)
+
+    df = exp.select(a=0.1)
+    assert len(df) == 1
+    assert df.iloc[0]["score"] == 1.0
+
+
+def test_handles_missing_metrics(temp_dir):
+    exp = Experiment("test_exp", base_dir=temp_dir)
+    log = exp.add(b=5)
+    exp.record(log)  # no metrics.json written
+    df = exp.to_dataframe()
+    assert df.iloc[0]["status"] == "missing"
+
+
+def test_handles_corrupt_metrics(temp_dir):
+    exp = Experiment("test_exp", base_dir=temp_dir)
+    log = exp.add(c=3)
+    path = log.path / "artifacts" / "metrics.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{not: valid json")
+    exp.record(log)
+    df = exp.to_dataframe()
+    assert df.iloc[0]["status"] == "error"
+
+
+def test_callback_invoked_on_mark_complete(temp_dir):
+    exp = Experiment("callback_exp", base_dir=temp_dir)
+    log = exp.add(x=42)
+
+    metrics = {"accuracy": 0.99}
+    metrics_path = log.path / "artifacts" / "metrics.json"
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    metrics_path.write_text(json.dumps(metrics))
+
+    log.mark_complete()
+
+    index_df = exp.to_dataframe()
+    assert len(index_df) == 1
+    row = index_df.iloc[0]
+    assert row["run_id"] == log.run_id
+    assert row["status"] == "complete"
+    assert row["accuracy"] == 0.99
+    assert row["x"] == 42


### PR DESCRIPTION
- Introduced `Experiment` class to manage and index multiple Logbook runs
- Added support for parameter sweeps, auto-generated run_ids, and CSV indexing
- Implemented `skip_existing` flag in `Experiment.add` to avoid duplicate runs
- Integrated callback mechanism into `Logbook` for automatic index updates
- Added tests for Experiment API coverage
- Extended documentation: new `experiment.rst` tutorial and updated quickstart


resolves #1 